### PR TITLE
Fix typo in docs

### DIFF
--- a/doc/contrib/index.html
+++ b/doc/contrib/index.html
@@ -33,7 +33,7 @@ distribution.
   </dd>
 
   <p>
-  <dt>The <a href="mod_auth_otp.html"><code>mod_ban</code></a> module
+  <dt>The <a href="mod_auth_otp.html"><code>mod_auth_otp</code></a> module
   <dd>For supporting HOTP/TOTP One-Time Passwords (OTP) for multi-factor
       authentication, <i>e.g.</i> using Google Authenticator
   </dd>


### PR DESCRIPTION
this fixes the link name on the docs/contrib index page for mod_auth_otp.